### PR TITLE
fix: rename sizeMode to autoResize in RichTextContentOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-specification",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Galacean Effects JSON Specification",
   "module": "./es/index.js",
   "main": "./es/index.js",

--- a/src/item/rich-text-item.ts
+++ b/src/item/rich-text-item.ts
@@ -45,7 +45,7 @@ export interface RichTextContentOptions extends BaseTextContentOptions {
    * 尺寸模式
    * @default TextSizeMode.autoWidth
    */
-  sizeMode?: TextSizeMode,
+  autoResize?: TextSizeMode,
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Public option renamed: replace any usage of "sizeMode" with "autoResize". Functionality remains the same, but integrations must update the option name.

* **Chores**
  * Package version bumped to 2.7.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->