### PR TITLE
chore: bump version to 2.8.1 and remove engines field

### DIFF
--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -6,9 +6,9 @@ Follow these steps in order:
 
 1. Run `git status` to see what files have changed
 2. Run `git diff` to review the changes
-3. Stage the appropriate files with `git add`
-4. Create a commit with a clear, descriptive message following conventional commits format
-5. If the current branch is the same as the target branch, create a new branch with `git checkout -b <branch>` (ensure the branch name is reasonable and follows naming conventions)
+3. If the current branch is the same as the target branch, create a new branch with `git checkout -b <branch>` first (ensure the branch name is reasonable and follows naming conventions)
+4. Stage the appropriate files with `git add`
+5. Create a commit with a clear, descriptive message following conventional commits format
 6. Push to the remote branch (create remote branch if needed with `-u origin <branch>`)
 7. Create a Pull Request using `gh pr create --base $name` with (If no name argument was provided, use main instead):
    - A clear title summarizing the changes (must use English)

--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -6,11 +6,12 @@ Follow these steps in order:
 
 1. Run `git status` to see what files have changed
 2. Run `git diff` to review the changes
-3. If the current branch is the same as the target branch, create a new branch with `git checkout -b <branch>` first (ensure the branch name is reasonable and follows naming conventions)
-4. Stage the appropriate files with `git add`
-5. Create a commit with a clear, descriptive message following conventional commits format
-6. Push to the remote branch (create remote branch if needed with `-u origin <branch>`)
-7. Create a Pull Request using `gh pr create --base $name` with (If no name argument was provided, use main instead):
+3. If no files are staged, run `git add -A .` to stage all changes; otherwise skip
+4. Run `git diff --staged` to review staged changes and generate a commit message following conventional commits format. Show the message and ask for explicit confirmation with choices: `Confirm commit` / `Cancel`. Only proceed if confirmed
+5. If the command arguments contain `-b`, or the current branch is `main`, `master`, `dev`, or matches `feat/<version>` (e.g. `feat/2.1`): infer a branch name from the staged diff content in `<type>/<scope>-<summary>` format and run `git checkout -b <branch>`; otherwise stay on the current branch
+6. Run `git commit -m "<message>"`
+7. Push to the remote branch (create remote branch if needed with `-u origin <branch>`)
+8. Create a Pull Request using `gh pr create --base $name` with (If no name argument was provided, use main instead):
    - A clear title summarizing the changes (must use English)
    - A description with (you can use Simplified-Chinese):
      - Summary of what changed and why

--- a/.claude/commands/quick-commit.md
+++ b/.claude/commands/quick-commit.md
@@ -4,7 +4,7 @@ description: "Stage all changes and commit with a descriptive message"
 
 1. Run `git status` to see the current state
 2. Run `git diff` to understand the changes
-3. Stage all changes with `git add -A`
+3. If no files are staged, run `git add -A .` to stage all changes; otherwise skip
 4. Create a commit with a clear message that:
    - Starts with a type prefix (feat:, fix:, refactor:, docs:, test:, chore:)
    - Briefly describes what changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/effects-specification",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Galacean Effects JSON Specification",
   "module": "./es/index.js",
   "main": "./es/index.js",
@@ -42,10 +42,6 @@
     "pnpm": "^8.15.7",
     "rimraf": "^3.0.2",
     "typescript": "^5.3.3"
-  },
-  "engines": {
-    "node": "18",
-    "pnpm": "8"
   },
   "author": "Ant Group CO., Ltd.",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- 版本号从 2.8.0 升级到 2.8.1
- 移除了 `package.json` 中的 `engines` 字段（node: 18, pnpm: 8），解除引擎版本绑定限制

## Test

- 本地验证 `package.json` 修改正确，无语法错误

## Notes

- 移除 `engines` 字段可以让项目在更多版本的 Node.js 和 pnpm 环境下使用，提升兼容性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to `2.8.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->